### PR TITLE
Procfile-only Group

### DIFF
--- a/bionic-order.toml
+++ b/bionic-order.toml
@@ -37,3 +37,8 @@ group = [
 group = [
   { id = "org.cloudfoundry.dotnet-core" },
 ]
+
+[[order]]
+group = [
+  { id = "org.cloudfoundry.procfile" },
+]

--- a/cflinuxfs3-order.toml
+++ b/cflinuxfs3-order.toml
@@ -57,3 +57,8 @@ group = [
 group = [
   { id = "org.cloudfoundry.nginx" },
 ]
+
+[[order]]
+group = [
+  { id = "org.cloudfoundry.procfile" },
+]


### PR DESCRIPTION
In order to support running bare binaries, this change adds a group to the `bionic` and `cflinuxfs3` builders that includes only the `procfile-cnb`.  This means that if an application has a `Procfile`, and isn't any other type of application, it will run a command declared in the `Procfile`.