### PR TITLE
Image Labels Buildpack

### DIFF
--- a/bionic-order.toml
+++ b/bionic-order.toml
@@ -21,6 +21,7 @@ group = [
 
 ### Order is strictly enforced
   { id = "paketo-buildpacks/encrypt-at-rest",            optional = true },
+  { id = "paketo-buildpacks/image-labels",               optional = true },
 ]
 
 [[order]]

--- a/cflinuxfs3-order.toml
+++ b/cflinuxfs3-order.toml
@@ -21,6 +21,7 @@ group = [
 
 ### Order is strictly enforced
   { id = "paketo-buildpacks/encrypt-at-rest",            optional = true },
+  { id = "paketo-buildpacks/image-labels",               optional = true },
 ]
 
 [[order]]


### PR DESCRIPTION
This change adds an Image Labels buildpack to the Java group.  This buildpack allows a user to configure both OCI-standard and arbitrary labels on a created image using environment variables.

Note, this buildpack is not Java-specific and could be introduced into other buildpack groups.
