### PR TITLE
RFC: Add Procfile as stand-alone buildpack to Tiny builder

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you purposing to the overall language family?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and ikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -16,7 +16,7 @@
 
 {{Any source material used in the creation of the RFC should be put here.}}
 
-## Unresolved Questions and ikeshedding (Optional)
+## Unresolved Questions and Bikeshedding (Optional)
 
 {{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
 

--- a/rfcs/0006-add-procfile.md
+++ b/rfcs/0006-add-procfile.md
@@ -1,0 +1,22 @@
+# Stand-alone Procfile buildpack in the Tiny builder
+
+## Proposal
+
+The Procfile buildpack should be added as a stand-alone group to the Tiny
+builder's group orderings.
+
+## Motivation
+
+Adding the Procfile buildpack as a stand-alone order at the end of the group
+ordering list would provide users that want to run pre-built binaries on the
+smallest base image available a supported path to do so.
+
+## Source Material
+
+* The Procfile buildpack is alread a stand-alone buildpack in both the
+  [Base](https://github.com/paketo-buildpacks/base-builder/blob/77f77454f74f6eb1d71c9b2d38eb9194350f66da/builder.toml#L80-L84)
+  and the
+  [Full](https://github.com/paketo-buildpacks/full-builder/blob/8069fea85dab14880f1dc54fcba552bb9fce3e70/builder.toml#L100-L104)
+  builders.
+* The Procfile buildpack [supports the Tiny
+  stack](https://github.com/paketo-buildpacks/procfile/blob/a36fb09721cd8fa05215333379e406e20391612f/buildpack.toml#L26-L27).


### PR DESCRIPTION
[Readable](https://github.com/paketo-buildpacks/builder/blob/add-procfile/rfcs/0006-add-procfile.md)